### PR TITLE
lmdb: fix cursor.Put with empty values

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -230,7 +230,8 @@ func (c *Cursor) putNilKey(flags uint) error {
 //
 // See mdb_cursor_put.
 func (c *Cursor) Put(key, val []byte, flags uint) error {
-	if len(key) == 0 {
+	kn := len(key)
+	if kn == 0 {
 		return c.putNilKey(flags)
 	}
 	vn := len(val)
@@ -239,8 +240,8 @@ func (c *Cursor) Put(key, val []byte, flags uint) error {
 	}
 	ret := C.lmdbgo_mdb_cursor_put2(
 		c._c,
-		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(len(key)),
-		(*C.char)(unsafe.Pointer(&val[0])), C.size_t(len(val)),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(kn),
+		(*C.char)(unsafe.Pointer(&val[0])), C.size_t(vn),
 		C.uint(flags),
 	)
 	return operrno("mdb_cursor_put", ret)

--- a/lmdb/cursor_test.go
+++ b/lmdb/cursor_test.go
@@ -543,6 +543,88 @@ func TestCursor_PutMulti(t *testing.T) {
 	}
 }
 
+func TestCursor_Put(t *testing.T) {
+	env := setup(t)
+	defer clean(env, t)
+
+	var db DBI
+	err := env.Update(func(txn *Txn) (err error) {
+		db, err = txn.CreateDBI("testing")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = env.Update(func(txn *Txn) (err error) {
+		cur, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+
+		err = cur.Put([]byte("k"), []byte("foo"), 0)
+		if err != nil {
+			return err
+		}
+		v, err := txn.Get(db, []byte("k"))
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(v, []byte("foo")) {
+			t.Errorf("value: %q (!= \"foo\")", v)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+func TestCursor_Put_emptyValue(t *testing.T) {
+	env := setup(t)
+	defer clean(env, t)
+
+	var db DBI
+	err := env.Update(func(txn *Txn) (err error) {
+		db, err = txn.CreateDBI("testing")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = env.Update(func(txn *Txn) (err error) {
+		cur, err := txn.OpenCursor(db)
+		if err != nil {
+			return err
+		}
+
+		err = cur.Put([]byte("k"), nil, 0)
+		if err != nil {
+			return err
+		}
+		v, err := txn.Get(db, []byte("k"))
+		if err != nil {
+			return err
+		}
+		if len(v) != 0 {
+			t.Errorf("value: %q (!= \"\")", v)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func TestCursor_Del(t *testing.T) {
 	env := setup(t)
 	defer clean(env, t)


### PR DESCRIPTION
Cursor.Put would write "\x00" instead of an empty value, while txn.Put would do the right thing.

Closes #1 

Original upstream PR: https://github.com/bmatsuo/lmdb-go/pull/141
