### PR TITLE
Rename fork to github.com/PowerDNS/lmdb-go

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
   sync.Pool easier (#104/#105)
 
 ```
-go get github.com/bmatsuo/lmdb-go/exp/lmdbpool
+go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
 ```
 
 - Silence aggressive struct initializer warning from clang (#107)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,31 +1,33 @@
-#Release Change Log
+# Release Change Log
 
-##v1.9.0-dev
+## v1.9.0-dev
 
-- Fix unsafe threading behavior in benchmarks (#101)
-- Update transactions no longer allocate `MDB_val` objects (#102)
-- Txn.Renew no longer clears the Txn finalizer -- prevents resource leaks (#104)
+Changes predating the PowerDNS fork (up to 2017):
+
+- Fix unsafe threading behavior in benchmarks (bmatsuo/lmdb-go#101)
+- Update transactions no longer allocate `MDB_val` objects (bmatsuo/lmdb-go#102)
+- Txn.Renew no longer clears the Txn finalizer -- prevents resource leaks (bmatsuo/lmdb-go#104)
 - Txn.Pooled field added so that the Txn finalizer may work better with
-  sync.Pool (#104/#105)
-- Fixed a race in the Txn finalizer that could lead to a segfault (#105)
+  sync.Pool (bmatsuo/lmdb-go#104 bmatsuo/lmdb-go#105)
+- Fixed a race in the Txn finalizer that could lead to a segfault (bmatsuo/lmdb-go#105)
 - Txn.RunOp method added so that it is possible for other packages to create
-  other flavors of managed transactions from scratch (#105)
+  other flavors of managed transactions from scratch (bmatsuo/lmdb-go#105)
 - Experimental package lmdbpool was added to make integration of lmdb and
-  sync.Pool easier (#104/#105)
+  sync.Pool easier (bmatsuo/lmdb-go#104 bmatsuo/lmdb-go#105)
 
 ```
 go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
 ```
 
-- Silence aggressive struct initializer warning from clang (#107)
+- Silence aggressive struct initializer warning from clang (bmatsuo/lmdb-go#107)
 - Improved documentation regarding long-running transactions and dead readers
-  (#111)
+  (bmatsuo/lmdb-go#111)
 
-##v1.8.0 (2017-02-10)
+## v1.8.0 (2017-02-10)
 
 - lmdbscan: The package was moved out of the exp/ subtree and can now be
   considered stable and suitable for general use.
-- lmdb: Update LMDB C library to version 0.9.19 (#92).
+- lmdb: Update LMDB C library to version 0.9.19 (bmatsuo/lmdb-go#92).
 
 ```
 	Fix mdb_env_cwalk cursor init (ITS#8424)
@@ -51,38 +53,38 @@ go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
 ```
 
 - lmdb: Fix resource leak in cursor tests (bcf4e9f).
-- lmdb: Fix panic in Cursor.Get when using the Set op (#96).
+- lmdb: Fix panic in Cursor.Get when using the Set op (bmatsuo/lmdb-go#96).
 - docs: Improve documentation about when runtime.LockOSThread is required
 
-##v1.7.0
+## v1.7.0
 
-- lmdb: Removed unnecessary import of the "math" package (#70).
+- lmdb: Removed unnecessary import of the "math" package (bmatsuo/lmdb-go#70).
 - lmdb: Removed direct dependency on the "fmt" package and reduced error
-  related allocation (#73).
+  related allocation (bmatsuo/lmdb-go#73).
 - cmd/lmdb_stat: Fix transaction ID decoding and match output of `mdb_stat`
-  1-to-1 (#78).
-- lmdb: fix compilation for 32-bit architectures (#83).
+  1-to-1 (bmatsuo/lmdb-go#78).
+- lmdb: fix compilation for 32-bit architectures (bmatsuo/lmdb-go#83).
 
-##v1.6.0 (2016-04-07)
+## v1.6.0 (2016-04-07)
 
-- lmdb: method Txn.ID() exposing mdb_txn_id. (#47)
-- lmdb: Env.ReaderList() returns an error if passed a nil function. (#48)
-- lmdbsync: realistic test of resizing functionality (#7)
-- lmdbsync: use context.Context instead of a hand-rolled Bag (#51)
-- lmdbsync: Handler Env is now an argument instead of a context value (#52)
-- lmdbsync: Changes to MapResizedHandler and its default values (#54)
+- lmdb: method Txn.ID() exposing mdb_txn_id. (bmatsuo/lmdb-go#47)
+- lmdb: Env.ReaderList() returns an error if passed a nil function. (bmatsuo/lmdb-go#48)
+- lmdbsync: realistic test of resizing functionality (bmatsuo/lmdb-go#7)
+- lmdbsync: use context.Context instead of a hand-rolled Bag (bmatsuo/lmdb-go#51)
+- lmdbsync: Handler Env is now an argument instead of a context value (bmatsuo/lmdb-go#52)
+- lmdbsync: Changes to MapResizedHandler and its default values (bmatsuo/lmdb-go#54)
 - lmdb: Fix CGO argument check panic for certain []byte values produced from a
-  bytes.Buffer (#56)
+  bytes.Buffer (bmatsuo/lmdb-go#56)
 - lmdb: Support building the C library with support for the pwritev(2) system
-  call (#58)
+  call (bmatsuo/lmdb-go#58)
 - lmdb: Reuse MDB_val values within transactions to reduce allocations in
-  transactions issuing multiple Get operations (#61).
+  transactions issuing multiple Get operations (bmatsuo/lmdb-go#61).
 - lmdb: Avoid allocation and linear scan overhead on the cgo boundary for
-  transaction operations (Get/Put and variants) (#63).
+  transaction operations (Get/Put and variants) (bmatsuo/lmdb-go#63).
 - lmdb: Use a more portable internal conversion from C pointers to slices
-  (#67).
+  (bmatsuo/lmdb-go#67).
 
-##v1.5.0
+## v1.5.0
 
 - lmdb: fix crash from bad interaction with Txn finalizer and Txn.Reset/.Renew.
 - lmdb: Update the LMDB C library to 0.9.18
@@ -103,7 +105,7 @@ go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
         Update WRITEMAP description
 ```
 
-##v1.4.0
+## v1.4.0
 
 - development: The LMDB C library can be cloned under /lmdb -- it will be
   ignored.
@@ -150,19 +152,19 @@ go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
 ```
 
 
-##v1.3.0
+## v1.3.0
 
-- all: Builds on Windows with passing tests. Fixes #33.
-- lmdb: Cursor.DBI returns "invalid" DBI if the cursor is closed. Fixes #31.
-- lmdb: Finalizers to prevent resource leaks. Fixes #20.
+- all: Builds on Windows with passing tests. Fixes bmatsuo/lmdb-go#33.
+- lmdb: Cursor.DBI returns "invalid" DBI if the cursor is closed. Fixes bmatsuo/lmdb-go#31.
+- lmdb: Finalizers to prevent resource leaks. Fixes bmatsuo/lmdb-go#20.
 - all: Internal test package for setting up, populating, and tearing down environments.
-- lmdbscan: Fix panic in Scanner.Scan after Txn.OpenCursor fails. Fixes #21.
+- lmdbscan: Fix panic in Scanner.Scan after Txn.OpenCursor fails. Fixes bmatsuo/lmdb-go#21.
 - lmdbscan: Scanner.Set[Next] methods move the cursor and make the next
-  Scanner.Scan a noop.  The changes should be backwards compatible. Fixes #17.
-- lmdb: Cgo calling convention meets rules set forth for go1.6. Fixes #10.
+  Scanner.Scan a noop.  The changes should be backwards compatible. Fixes bmatsuo/lmdb-go#17.
+- lmdb: Cgo calling convention meets rules set forth for go1.6. Fixes bmatsuo/lmdb-go#10.
 - lmdb: add a "Package" code example that shows a complete workflow
 
-##v1.2.0
+## v1.2.0
 
 - Many example tests replaced with simpler code examples.
 - Lots of documentation fixes
@@ -172,7 +174,7 @@ go get github.com/PowerDNS/lmdb-go/exp/lmdbpool
 - lmdb: Implement Env.FD() method returning an open file descriptor
 - lmdbgo.c: remove unnecessary `#include <string.h>`
 
-##v1.1.1
+## v1.1.1
 
 - Lots of code examples.
 - Lots of tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The lmdb-go is grateful for any outside contributions.  The simplest way to
 contribute is to comment on [open
-issues](https://github.com/bmatsuo/lmdb-go/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
+issues](https://github.com/PowerDNS/lmdb-go/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
 that are important to you.  This is a critical component in ensuring that
 lmdb-go evolves in ways that are best for everyone.
 
@@ -14,7 +14,7 @@ open issues and add relevant new input there if necessary.
 
 If there is a problem with lmdb-go that is not being addressed in an open issue
 then a new issue should be
-[opened](https://github.com/bmatsuo/lmdb-go/issues/new).  All users are
+[opened](https://github.com/PowerDNS/lmdb-go/issues/new).  All users are
 encouraged to file issues when they encounter behavior that is incorrect or
 inconsistent.  Proposals for new or expanded features/behavior are also welcome
 and will be considered. But such proposals must adequately describe the problem

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Bryan Matsuo
+Copyright (c) 2015-now, Bryan Matsuo & contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#lmdb-go [![releases/v1.8.0](https://img.shields.io/badge/release-v1.8.0-375eab.svg)](releases) [![C/v0.9.19](https://img.shields.io/badge/C-v0.9.19-555555.svg)](https://github.com/LMDB/lmdb/blob/mdb.RE/0.9/libraries/liblmdb/CHANGES) [![Build Status](https://travis-ci.org/bmatsuo/lmdb-go.svg?branch=master)](https://travis-ci.org/bmatsuo/lmdb-go)
+# lmdb-go [![releases/v1.8.0](https://img.shields.io/badge/release-v1.8.0-375eab.svg)](releases) [![C/v0.9.19](https://img.shields.io/badge/C-v0.9.19-555555.svg)](https://github.com/LMDB/lmdb/blob/mdb.RE/0.9/libraries/liblmdb/CHANGES) [![Build Status](https://travis-ci.org/bmatsuo/lmdb-go.svg?branch=master)](https://travis-ci.org/bmatsuo/lmdb-go)
 
 Go bindings to the OpenLDAP Lightning Memory-Mapped Database (LMDB).
 
@@ -14,7 +14,7 @@ and pinned by tag/commit.
 
 Developers concerned with package stability should consult the documentation.
 
-####lmdb [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
+#### lmdb [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
 
 ```go
 import "github.com/bmatsuo/lmdb-go/lmdb"
@@ -22,7 +22,7 @@ import "github.com/bmatsuo/lmdb-go/lmdb"
 
 Core bindings allowing low-level access to LMDB.
 
-####lmdbscan [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
+#### lmdbscan [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
 
 ```go
 import "github.com/bmatsuo/lmdb-go/lmdbscan"
@@ -32,7 +32,7 @@ A utility package for scanning database ranges. The API is inspired by
 [bufio.Scanner](https://godoc.org/bufio#Scanner) and the python cursor
 [implementation](https://lmdb.readthedocs.org/en/release/#cursor-class).
 
-####exp/lmdbpool [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
+#### exp/lmdbpool [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
 
 
 ```go
@@ -51,7 +51,7 @@ through use by real applications it can be integrated directly into the lmdb
 package for more transparent integration.  Please test this package and provide
 feedback to speed this process up.
 
-####exp/lmdbsync [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
+#### exp/lmdbsync [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
 
 
 ```go
@@ -71,7 +71,7 @@ provided implementations can be considered stable.
 
 ## Key Features
 
-###Idiomatic API
+### Idiomatic API
 
 API inspired by [BoltDB](https://github.com/boltdb/bolt) with automatic
 commit/rollback of transactions.  The goal of lmdb-go is to provide idiomatic
@@ -91,7 +91,7 @@ functionality.  Consult the
 [documentation](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) for
 more information about the lmdbsync package.
 
-###API coverage
+### API coverage
 
 The lmdb-go project aims for complete coverage of the LMDB C API (within
 reason).  Some notable features and optimizations that are supported:
@@ -106,7 +106,7 @@ reason).  Some notable features and optimizations that are supported:
 For tracking purposes a list of unsupported features is kept in an
 [issue](https://github.com/bmatsuo/lmdb-go/issues/1).
 
-###Zero-copy reads
+### Zero-copy reads
 
 Applications with high performance requirements can opt-in to fast, zero-copy
 reads at the cost of runtime safety.  Zero-copy behavior is specified at the
@@ -123,7 +123,7 @@ err := lmdb.View(func(txn *lmdb.Txn) error {
 })
 ```
 
-###Documentation
+### Documentation
 
 Comprehensive documentation and examples are provided to demonstrate safe usage
 of lmdb.  In addition to [godoc](https://godoc.org/github.com/bmatsuo/lmdb-go)
@@ -133,13 +133,13 @@ commands can be found in the [exp/cmd/](exp/cmd) directory.  Aside from
 providing minor utility these programs are provided as examples of lmdb in
 practice.
 
-##LMDB compared to BoltDB
+## LMDB compared to BoltDB
 
 BoltDB is a quality database with a design similar to LMDB.  Both store
 key-value data in a file and provide ACID transactions.  So there are often
 questions of why to use one database or the other.
 
-###Advantages of BoltDB
+### Advantages of BoltDB
 
 - Nested databases allow for hierarchical data organization.
 
@@ -157,7 +157,7 @@ questions of why to use one database or the other.
   information about caveats with the lmdb package, consult its
   [documentation](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb).
 
-###Advantages of LMDB
+### Advantages of LMDB
 
 - Keys can contain multiple values using the DupSort flag.
 
@@ -182,7 +182,7 @@ questions of why to use one database or the other.
   databases.  Mission critical Go applications can use a database while Python
   scripts perform analysis on the side.
 
-##Build
+## Build
 
 There is no dependency on shared libraries.  So most users can simply install
 using `go get`.
@@ -208,9 +208,9 @@ required when committing a transaction. In your own package you can then do
 
 to enable the optimisation.
 
-##Documentation
+## Documentation
 
-###Go doc
+### Go doc
 
 The `go doc` documentation available on
 [godoc.org](https://godoc.org/github.com/bmatsuo/lmdb-go) is the primary source
@@ -218,7 +218,7 @@ of developer documentation for lmdb-go.  It provides an overview of the API
 with a lot of usage examples.  Where necessary the documentation points out
 differences between the semantics of methods and their C counterparts.
 
-###LMDB
+### LMDB
 
 The LMDB [homepage](http://symas.com/mdb/) and mailing list
 ([archives](http://www.openldap.org/lists/openldap-technical/)) are the
@@ -230,7 +230,7 @@ Along with an API reference LMDB provides a high-level
 lmdb-go abstracts many of the thread and transaction details by default the
 rest of the guide is still useful to compare with `go doc`.
 
-###Versioning and Stability
+### Versioning and Stability
 
 The lmdb-go project makes regular releases with IDs `X.Y.Z`.  All packages
 outside of the `exp/` directory are considered stable and adhere to the
@@ -244,22 +244,22 @@ The API of an unstable package may change in subtle ways between minor release
 versions.  But deprecations will be indicated at least one release in advance
 and all functionality will remain available through some method.
 
-##License
+## License
 
 Except where otherwise noted files in the lmdb-go project are licensed under
 the BSD 3-clause open source license.
 
 The LMDB C source is licensed under the OpenLDAP Public License.
 
-##Links
+## Links
 
-####[github.com/bmatsuo/raft-mdb](https://github.com/bmatsuo/raft-mdb) ([godoc](https://godoc.org/github.com/bmatsuo/raft-mdb))
+#### [github.com/bmatsuo/raft-mdb](https://github.com/bmatsuo/raft-mdb) ([godoc](https://godoc.org/github.com/bmatsuo/raft-mdb))
 
 An experimental backend for
 [github.com/hashicorp/raft](https://github.com/hashicorp/raft) forked from
 [github.com/hashicorp/raft-mdb](https://github.com/hashicorp/raft-mdb).
 
-####[github.com/bmatsuo/cayley/graph/lmdb](https://github.com/bmatsuo/cayley/tree/master/graph/lmdb) ([godoc](https://godoc.org/github.com/bmatsuo/cayley/graph/lmdb))
+#### [github.com/bmatsuo/cayley/graph/lmdb](https://github.com/bmatsuo/cayley/tree/master/graph/lmdb) ([godoc](https://godoc.org/github.com/bmatsuo/cayley/graph/lmdb))
 
 Experimental backend quad-store for
 [github.com/google/cayley](https://github.com/google/cayley) based off of the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-# lmdb-go [![releases/v1.8.0](https://img.shields.io/badge/release-v1.8.0-375eab.svg)](releases) [![C/v0.9.19](https://img.shields.io/badge/C-v0.9.19-555555.svg)](https://github.com/LMDB/lmdb/blob/mdb.RE/0.9/libraries/liblmdb/CHANGES) [![Build Status](https://travis-ci.org/bmatsuo/lmdb-go.svg?branch=master)](https://travis-ci.org/bmatsuo/lmdb-go)
+# lmdb-go [![releases/v1.8.0](https://img.shields.io/badge/release-v1.8.0-375eab.svg)](releases) [![C/v0.9.19](https://img.shields.io/badge/C-v0.9.19-555555.svg)](https://github.com/LMDB/lmdb/blob/mdb.RE/0.9/libraries/liblmdb/CHANGES) [![Build Status](https://travis-ci.com/PowerDNS/lmdb-go.svg?branch=master)](https://travis-ci.com/PowerDNS/lmdb-go)
 
 Go bindings to the OpenLDAP Lightning Memory-Mapped Database (LMDB).
+
+## About this fork
+
+This fork was created after the upstream repository [bmatsuo/lmdb-go](https://github.com/bmatsuo/lmdb-go)
+went without updates for 4 years. We would like to express our thanks to
+*bmatsuo* for creating and maintaining this repository until 2017.
+
+We decided to rename this repository to allow usage without `replace`
+directives in the `go.mod`, as we do not expect this to be a temporary
+fork. This also makes it clear that new versions released here are
+different from any upstream versions.
+
+To use this package, update all your import paths from
+`github.com/bmatsuo/lmdb-go` to `github.com/PowerDNS/lmdb-go`.
+
+This affects all versions starting from 1.9.0.
+
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -14,29 +14,29 @@ and pinned by tag/commit.
 
 Developers concerned with package stability should consult the documentation.
 
-#### lmdb [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
+#### lmdb [![GoDoc](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdb?status.svg)](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdb) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
 
 ```go
-import "github.com/bmatsuo/lmdb-go/lmdb"
+import "github.com/PowerDNS/lmdb-go/lmdb"
 ```
 
 Core bindings allowing low-level access to LMDB.
 
-#### lmdbscan [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdbscan) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
+#### lmdbscan [![GoDoc](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdbscan?status.svg)](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdbscan) [![stable](https://img.shields.io/badge/stability-stable-brightgreen.svg)](#user-content-versioning-and-stability)
 
 ```go
-import "github.com/bmatsuo/lmdb-go/lmdbscan"
+import "github.com/PowerDNS/lmdb-go/lmdbscan"
 ```
 
 A utility package for scanning database ranges. The API is inspired by
 [bufio.Scanner](https://godoc.org/bufio#Scanner) and the python cursor
 [implementation](https://lmdb.readthedocs.org/en/release/#cursor-class).
 
-#### exp/lmdbpool [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
+#### exp/lmdbpool [![GoDoc](https://godoc.org/github.com/PowerDNS/lmdb-go/exp/lmdbpool?status.svg)](https://godoc.org/github.com/PowerDNS/lmdb-go/exp/lmdbpool) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
 
 
 ```go
-import "github.com/bmatsuo/lmdb-go/exp/lmdbpool"
+import "github.com/PowerDNS/lmdb-go/exp/lmdbpool"
 ```
 
 A utility package which facilitates reuse of lmdb.Txn objects using a
@@ -51,11 +51,11 @@ through use by real applications it can be integrated directly into the lmdb
 package for more transparent integration.  Please test this package and provide
 feedback to speed this process up.
 
-#### exp/lmdbsync [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
+#### exp/lmdbsync [![GoDoc](https://godoc.org/github.com/PowerDNS/lmdb-go/exp/lmdbsync?status.svg)](https://godoc.org/github.com/PowerDNS/lmdb-go/exp/lmdbsync) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability)
 
 
 ```go
-import "github.com/bmatsuo/lmdb-go/exp/lmdbsync"
+import "github.com/PowerDNS/lmdb-go/exp/lmdbsync"
 ```
 
 An experimental utility package that provides synchronization necessary to
@@ -81,14 +81,14 @@ database interactions without compromising the flexibility of the C API.
 possible there are compromises, gotchas, and caveats that application
 developers must be aware of when relying on LMDB to store their data.  All
 users are encouraged to fully read the
-[documentation](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb) so they are
+[documentation](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdb) so they are
 aware of these caveats.
 
 Where the lmdb package and its implementation decisions do not meet the needs
 of application developers in terms of safety or operational use the lmdbsync
 package has been designed to wrap lmdb and safely fill in additional
 functionality.  Consult the
-[documentation](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) for
+[documentation](https://godoc.org/github.com/PowerDNS/lmdb-go/exp/lmdbsync) for
 more information about the lmdbsync package.
 
 ### API coverage
@@ -104,7 +104,7 @@ reason).  Some notable features and optimizations that are supported:
   `[]byte`.
 
 For tracking purposes a list of unsupported features is kept in an
-[issue](https://github.com/bmatsuo/lmdb-go/issues/1).
+[issue](https://github.com/PowerDNS/lmdb-go/issues/1).
 
 ### Zero-copy reads
 
@@ -126,7 +126,7 @@ err := lmdb.View(func(txn *lmdb.Txn) error {
 ### Documentation
 
 Comprehensive documentation and examples are provided to demonstrate safe usage
-of lmdb.  In addition to [godoc](https://godoc.org/github.com/bmatsuo/lmdb-go)
+of lmdb.  In addition to [godoc](https://godoc.org/github.com/PowerDNS/lmdb-go)
 documentation, implementations of the standand LMDB commands (`mdb_stat`, etc)
 can be found in the [cmd/](cmd/) directory and some simple experimental
 commands can be found in the [exp/cmd/](exp/cmd) directory.  Aside from
@@ -155,7 +155,7 @@ questions of why to use one database or the other.
 - Its simpler design and implementation in pure Go mean it is free of many
   caveats and gotchas which are present using the lmdb package.  For more
   information about caveats with the lmdb package, consult its
-  [documentation](https://godoc.org/github.com/bmatsuo/lmdb-go/lmdb).
+  [documentation](https://godoc.org/github.com/PowerDNS/lmdb-go/lmdb).
 
 ### Advantages of LMDB
 
@@ -187,7 +187,7 @@ questions of why to use one database or the other.
 There is no dependency on shared libraries.  So most users can simply install
 using `go get`.
 
-`go get github.com/bmatsuo/lmdb-go/lmdb`
+`go get github.com/PowerDNS/lmdb-go/lmdb`
 
 On FreeBSD 10, you must explicitly set `CC` (otherwise it will fail with a
 cryptic error), for example:
@@ -213,7 +213,7 @@ to enable the optimisation.
 ### Go doc
 
 The `go doc` documentation available on
-[godoc.org](https://godoc.org/github.com/bmatsuo/lmdb-go) is the primary source
+[godoc.org](https://godoc.org/github.com/PowerDNS/lmdb-go) is the primary source
 of developer documentation for lmdb-go.  It provides an overview of the API
 with a lot of usage examples.  Where necessary the documentation points out
 differences between the semantics of methods and their C counterparts.

--- a/cmd/lmdb_copy/main.go
+++ b/cmd/lmdb_copy/main.go
@@ -14,8 +14,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbcmd"
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbcmd"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 func main() {

--- a/cmd/lmdb_stat/main.go
+++ b/cmd/lmdb_stat/main.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbcmd"
-	"github.com/bmatsuo/lmdb-go/lmdb"
-	"github.com/bmatsuo/lmdb-go/lmdbscan"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbcmd"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdbscan"
 )
 
 func main() {

--- a/exp/cmd/lmdb_cat/main.go
+++ b/exp/cmd/lmdb_cat/main.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bmatsuo/lmdb-go/exp/lmdbsync"
-	"github.com/bmatsuo/lmdb-go/internal/lmdbcmd"
-	"github.com/bmatsuo/lmdb-go/lmdb"
-	"github.com/bmatsuo/lmdb-go/lmdbscan"
+	"github.com/PowerDNS/lmdb-go/exp/lmdbsync"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbcmd"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdbscan"
 )
 
 func main() {

--- a/exp/lmdbpool/txnpool.go
+++ b/exp/lmdbpool/txnpool.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // UpdateHandling describes how a TxnPool handles existing lmdb.Readonly

--- a/exp/lmdbsync/handler.go
+++ b/exp/lmdbsync/handler.go
@@ -8,7 +8,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // Handler can intercept errors returned by a transaction and handle them in an

--- a/exp/lmdbsync/handler_test.go
+++ b/exp/lmdbsync/handler_test.go
@@ -7,8 +7,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbtest"
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbtest"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 type testHandler struct {

--- a/exp/lmdbsync/lmdbsync.go
+++ b/exp/lmdbsync/lmdbsync.go
@@ -113,7 +113,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // Env wraps an *lmdb.Env, receiving all the same methods and proxying some to

--- a/exp/lmdbsync/lmdbsync_test.go
+++ b/exp/lmdbsync/lmdbsync_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbtest"
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbtest"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 var optNoLock = &lmdbtest.EnvOptions{Flags: lmdb.NoLock}

--- a/exp/lmdbsync/testresize/main.go
+++ b/exp/lmdbsync/testresize/main.go
@@ -28,8 +28,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/bmatsuo/lmdb-go/exp/lmdbsync"
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/exp/lmdbsync"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 func main() {

--- a/exp/lmdbsync/testresize_test.go
+++ b/exp/lmdbsync/testresize_test.go
@@ -13,7 +13,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 func TestResize(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bmatsuo/lmdb-go
+module github.com/PowerDNS/lmdb-go
 
 go 1.15
 

--- a/internal/lmdbcmd/cmutil.go
+++ b/internal/lmdbcmd/cmutil.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 var flagPrintVersion bool

--- a/internal/lmdbtest/lmdbtest.go
+++ b/internal/lmdbtest/lmdbtest.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // ItemList is a list of database items.

--- a/lmdb/example_test.go
+++ b/lmdb/example_test.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // These values shouldn't actually be assigned to.  The are used as stand-ins

--- a/lmdb/lmdbgo.c
+++ b/lmdb/lmdbgo.c
@@ -1,5 +1,5 @@
 /* lmdbgo.c
- * Helper utilities for github.com/bmatsuo/lmdb-go/lmdb
+ * Helper utilities for github.com/PowerDNS/lmdb-go/lmdb
  * */
 #include "lmdb.h"
 #include "lmdbgo.h"

--- a/lmdb/lmdbgo.h
+++ b/lmdb/lmdbgo.h
@@ -1,5 +1,5 @@
 /* lmdbgo.h
- * Helper utilities for github.com/bmatsuo/lmdb-go/lmdb.  These functions have
+ * Helper utilities for github.com/PowerDNS/lmdb-go/lmdb.  These functions have
  * no compatibility guarantees and may be modified or deleted without warning.
  * */
 #ifndef _LMDBGO_H_
@@ -15,7 +15,7 @@
  * problem and the decision.
  *      https://github.com/golang/go/issues/14387
  *      https://github.com/golang/go/issues/15048
- *      https://github.com/bmatsuo/lmdb-go/issues/63
+ *      https://github.com/PowerDNS/lmdb-go/issues/63
  * */
 int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn);
 int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val);

--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -10,7 +10,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbarch"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbarch"
 )
 
 // valSizeBits is the number of bits which constraining the length of the

--- a/lmdbscan/example_test.go
+++ b/lmdbscan/example_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"log"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
-	"github.com/bmatsuo/lmdb-go/lmdbscan"
+	"github.com/PowerDNS/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdbscan"
 )
 
 var env *lmdb.Env

--- a/lmdbscan/scanner.go
+++ b/lmdbscan/scanner.go
@@ -6,7 +6,7 @@ package lmdbscan
 import (
 	"fmt"
 
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 // errClosed is an error returned to the user when attempting to operate on a

--- a/lmdbscan/scanner_test.go
+++ b/lmdbscan/scanner_test.go
@@ -5,8 +5,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/bmatsuo/lmdb-go/internal/lmdbtest"
-	"github.com/bmatsuo/lmdb-go/lmdb"
+	"github.com/PowerDNS/lmdb-go/internal/lmdbtest"
+	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
 type errcheck func(err error) (ok bool)


### PR DESCRIPTION
This fork was created after the upstream repository [bmatsuo/lmdb-go](https://github.com/bmatsuo/lmdb-go)
went without updates for 4 years. We would like to express our thanks to
*bmatsuo* for creating and maintaining this repository until 2017.

We decided to rename this repository to allow usage without `replace`
directives in the `go.mod`, as we do not expect this to be a temporary
fork. This also makes it clear that new versions released here are
different from any upstream versions.

To use this package, update all your import paths from
`github.com/bmatsuo/lmdb-go` to `github.com/PowerDNS/lmdb-go`.

This affects all versions starting from 1.9.0.

- Rename this module to `github.com/PowerDNS/lmdb-go` (closes #3)
- Fix formatting in markdown files
- Prefix issue number references with original repo name
- Add a note about this fork to the readme
