### PR TITLE
WIP: Optimize cursor operation for zero memory allocations

### DIFF
--- a/lmdb/error.go
+++ b/lmdb/error.go
@@ -19,7 +19,7 @@ type OpError struct {
 }
 
 // Error implements the error interface.
-func (err *OpError) Error() string {
+func (err OpError) Error() string {
 	return err.Op + ": " + err.Errno.Error()
 }
 
@@ -63,10 +63,10 @@ const (
 // Most often helper functions such as IsNotFound may be used instead of
 // dealing with Errno values directly.
 //
-//		lmdb.IsNotFound(err)
-//		lmdb.IsErrno(err, lmdb.TxnFull)
-//		lmdb.IsErrnoSys(err, syscall.EINVAL)
-//		lmdb.IsErrnoFn(err, os.IsPermission)
+//	lmdb.IsNotFound(err)
+//	lmdb.IsErrno(err, lmdb.TxnFull)
+//	lmdb.IsErrnoSys(err, syscall.EINVAL)
+//	lmdb.IsErrnoFn(err, os.IsPermission)
 type Errno C.int
 
 // minimum and maximum values produced for the Errno type. syscall.Errnos of
@@ -124,6 +124,9 @@ func IsErrnoFn(err error, fn func(error) bool) bool {
 		return false
 	}
 	if err, ok := err.(*OpError); ok {
+		return fn(err.Errno)
+	}
+	if err, ok := err.(OpError); ok {
 		return fn(err.Errno)
 	}
 	return fn(err)

--- a/lmdb/lmdbgo.c
+++ b/lmdb/lmdbgo.c
@@ -70,6 +70,14 @@ int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, char *kdata, size_t kn, char *vd
     return mdb_cursor_put(cur, &key, &val[0], flags);
 }
 
+int lmdbgo_mdb_cursor_get0(MDB_cursor *cur, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
+    return mdb_cursor_get(cur, key, val, op);
+}
+
+int lmdbgo_mdb_cursor_get0x(void *cur, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
+    return mdb_cursor_get(cur, key, val, op);
+}
+
 int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
     LMDBGO_SET_VAL(key, kn, kdata);
     return mdb_cursor_get(cur, key, val, op);

--- a/lmdb/lmdbgo.h
+++ b/lmdb/lmdbgo.h
@@ -24,6 +24,8 @@ int lmdbgo_mdb_put2(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vda
 int lmdbgo_mdb_cursor_put1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *val, unsigned int flags);
 int lmdbgo_mdb_cursor_put2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, unsigned int flags);
 int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, size_t vstride, unsigned int flags);
+int lmdbgo_mdb_cursor_get0(MDB_cursor *cur, MDB_val *key, MDB_val *val, MDB_cursor_op op);
+int lmdbgo_mdb_cursor_get0x(void *cur, MDB_val *key, MDB_val *val, MDB_cursor_op op);
 int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
 int lmdbgo_mdb_cursor_get2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
 

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -67,6 +67,8 @@ type Txn struct {
 	_txn *C.MDB_txn
 	key  *C.MDB_val
 	val  *C.MDB_val
+	keyV C.MDB_val
+	valV C.MDB_val
 
 	errLogf func(format string, v ...interface{})
 }


### PR DESCRIPTION
DO NOT MERGE

This is is a work in progress optimization I wrote a while ago. I noticed that certain cursor operations would always would allocate memory due to how CGo handled calls.

Unfortunately I forgot the details and the state of this code.

TODO:

- [ ] Add tests to check the memory allocation of the operations in question
- [ ] Check if this is still an issue in newer Go versions
- [ ] Add comments to the code to explain what is happening
- [ ] Cleanup

