### PR TITLE
Disable memcpy() overflow warnings in C compilation

### DIFF
--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -127,7 +127,7 @@ details about dealing with such situations.
 package lmdb
 
 /*
-#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -O2 -g
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -Wno-stringop-overflow -O2 -g
 #cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
 
 #include "lmdb.h"


### PR DESCRIPTION
Fixes #18 

This PR eliminates the warnings mentioned in #18. It uses a similar technique as was applied for other C compiler warnings in earlier commits.