### PR TITLE
Replace reflect.SliceHeader with unsafe.Slice

### DIFF
--- a/cmd/lmdb_stat/main.go
+++ b/cmd/lmdb_stat/main.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"reflect"
 	"strings"
 	"unsafe"
 
@@ -237,12 +236,8 @@ func doPrintFree(env *lmdb.Env, opt *Options) error {
 			numpages += ipages
 			if opt.PrintFreeSummary || opt.PrintFreeFull {
 				bad := ""
-				hdr := reflect.SliceHeader{
-					Data: uintptr(unsafe.Pointer(&data[0])),
-					Len:  int(ipages) + 1,
-					Cap:  int(ipages) + 1,
-				}
-				pages := *(*[]C.size_t)(unsafe.Pointer(&hdr))
+				datap := (*C.size_t)(unsafe.Pointer(&data[0]))
+				pages := unsafe.Slice(datap, ipages+1)
 				pages = pages[1:]
 				var span C.size_t
 				prev := C.size_t(1)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/PowerDNS/lmdb-go
 
-go 1.15
+go 1.17
 
 require golang.org/x/net v0.0.0-20210415231046-e915ea6b2b7d


### PR DESCRIPTION
Fixes part of #20 

This PR fixes the `go vet` warning caused by the use of `reflect.SliceHeader()` by replacing it with `unsafe.Slice()`.

----

I'm not 100% this actually works as desired, as the `unsafe` and `reflect` libraries both feel like voodoo to me. There don't seem to be tests in this area, but maybe I missed them?

----

This requires a version bump for Go:
```
./main.go:246:14: unsafe.Slice requires go1.17 or later (-lang was set to go1.15; check go.mod)
```

This is probably reasonable, since Go supports two major releases at a time:
https://go.dev/doc/devel/release#policy

And we're on Go 1.21, meaning that anything older than Go 1.19 is unsupported.

OTOH, I can see how dropping support for language release from less than 3 years ago could seem a bit aggressive. ¯\\\_(ツ)\_/¯

