### PR TITLE
Fix issues reported by staticcheck in tests

### DIFF
--- a/exp/lmdbsync/handler_test.go
+++ b/exp/lmdbsync/handler_test.go
@@ -55,13 +55,6 @@ func TestHandlerChain(t *testing.T) {
 	}
 }
 
-type retryHandler struct{}
-
-func (*retryHandler) HandleTxnErr(ctx context.Context, env *Env, err error) (context.Context, error) {
-	return ctx, ErrTxnRetry
-
-}
-
 type passthroughHandler struct{}
 
 func (*passthroughHandler) HandleTxnErr(ctx context.Context, env *Env, err error) (context.Context, error) {
@@ -91,6 +84,9 @@ func TestMapFullHandler(t *testing.T) {
 	ctx1, err := handler.HandleTxnErr(ctx, env, errother)
 	if ctx1 != ctx {
 		t.Errorf("ctx changed: %q (!= %q)", ctx1, ctx)
+	}
+	if err != errother {
+		t.Errorf("unexpected error: %v", err)
 	}
 
 	errmapfull := &lmdb.OpError{
@@ -127,6 +123,9 @@ func TestMapResizedHandler(t *testing.T) {
 
 	errother := fmt.Errorf("testerr")
 	_, err = handler.HandleTxnErr(ctx, env, errother)
+	if err != errother {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	errmapresized := &lmdb.OpError{
 		Op:    "lmdbsync_test_op",

--- a/lmdb/bench_test.go
+++ b/lmdb/bench_test.go
@@ -1605,12 +1605,6 @@ func openBenchDBI(b *testing.B, env *Env) DBI {
 	return dbi
 }
 
-func randBytes(n int) []byte {
-	p := make([]byte, n)
-	crand.Read(p)
-	return p
-}
-
 func bMust(b *testing.B, err error, action string) {
 	if err != nil {
 		b.Fatalf("error %s: %v", action, err)
@@ -1670,14 +1664,6 @@ func (c *randSourceCursor) NBytes(n int) []byte {
 		return p
 	}
 	return randSource[i : i+n]
-}
-
-func populateDBIString(t testing.TB, env *Env, dbi DBI, records []testRecordString) (ok bool) {
-	return populateDBI(t, env, dbi, testRecordSetString(records))
-}
-
-func populateDBIBytes(t testing.TB, env *Env, dbi DBI, records []testRecordBytes) (ok bool) {
-	return populateDBI(t, env, dbi, testRecordSetBytes(records))
 }
 
 func populateDBI(t testing.TB, env *Env, dbi DBI, records testRecordSet) (ok bool) {
@@ -1742,16 +1728,6 @@ type testRecordSet interface {
 	TestRecord(i int) testRecord
 }
 
-type testRecordSetString []testRecordString
-
-func (s testRecordSetString) Len() int                    { return len(s) }
-func (s testRecordSetString) TestRecord(i int) testRecord { return s[i] }
-
-type testRecordSetBytes []testRecordBytes
-
-func (s testRecordSetBytes) Len() int                    { return len(s) }
-func (s testRecordSetBytes) TestRecord(i int) testRecord { return s[i] }
-
 type testRecordGen struct {
 	n  int
 	fn testRecordFn
@@ -1771,8 +1747,3 @@ type testRecordBytes [2][]byte
 
 func (r testRecordBytes) Key() []byte  { return r[0] }
 func (r testRecordBytes) Data() []byte { return r[1] }
-
-type testRecordString [2][]byte
-
-func (r testRecordString) Key() []byte  { return []byte(r[0]) }
-func (r testRecordString) Data() []byte { return []byte(r[1]) }

--- a/lmdb/cursor_test.go
+++ b/lmdb/cursor_test.go
@@ -355,6 +355,9 @@ func TestCursor_Get_DupFixed(t *testing.T) {
 
 		for i := int64(0); i < int64(numitems); i++ {
 			err = txn.Put(dbi, key, []byte(fmt.Sprintf("%016x", i)), 0)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/lmdb/example_test.go
+++ b/lmdb/example_test.go
@@ -17,19 +17,14 @@ import (
 var EnvEx *lmdb.Env
 var DBIEx lmdb.DBI
 
-// These values can only be used is code-only examples (no test output).
+// These values can only be used in code-only examples (no test output).
 var env *lmdb.Env
-var txn *lmdb.Txn
 var dbi lmdb.DBI
-var dbname string
 var err error
 var stop chan struct{}
 
 // These values can be used as no-op placeholders in examples.
-func doUpdate(txn *lmdb.Txn) error  { return nil }
-func doUpdate1(txn *lmdb.Txn) error { return nil }
-func doUpdate2(txn *lmdb.Txn) error { return nil }
-func doView(txn *lmdb.Txn) error    { return nil }
+func doUpdate(txn *lmdb.Txn) error { return nil }
 
 // This example demonstrates a complete workflow for a simple application
 // working with LMDB.  First, an Env is configured and mapped to memory.  Once
@@ -219,8 +214,6 @@ retry:
 	}
 	// ...
 }
-
-func backupFailed(err error) {}
 
 // This example uses env.Copy to periodically create atomic backups of an
 // environment.  A real implementation would need to solve problems with

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -24,7 +24,7 @@ func TestTxn_ID(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if 0 != id0 {
+	if id0 != 0 {
 		t.Errorf("unexpected readonly id (before update): %v (!= %v)", id0, 0)
 	}
 
@@ -34,7 +34,7 @@ func TestTxn_ID(t *testing.T) {
 		return
 	}
 	defer txnCached.Abort()
-	if 0 != txnCached.ID() {
+	if txnCached.ID() != 0 {
 		t.Errorf("unexpected readonly id (before update): %v (!= %v)", txnCached.ID(), 0)
 	}
 	if txnCached.getID() != txnCached.ID() {
@@ -90,7 +90,7 @@ func TestTxn_ID(t *testing.T) {
 	if id1 != id2 {
 		t.Errorf("unexpected readonly id: %v (!= %v)", id2, id1)
 	}
-	if 0 != id3 {
+	if id3 != 0 {
 		t.Errorf("unexpected invalid id: %v (!= %v)", id3, 0)
 	}
 	if id1 != txnCached.ID() {
@@ -778,7 +778,7 @@ func TestTxn_Renew(t *testing.T) {
 		return
 	}
 	defer txn.Abort()
-	val, err := txn.Get(dbroot, []byte("k"))
+	_, err = txn.Get(dbroot, []byte("k"))
 	if !IsNotFound(err) {
 		t.Errorf("get: %v", err)
 	}
@@ -794,7 +794,7 @@ func TestTxn_Renew(t *testing.T) {
 		t.Error(err)
 	}
 
-	val, err = txn.Get(dbroot, []byte("k"))
+	_, err = txn.Get(dbroot, []byte("k"))
 	if !IsNotFound(err) {
 		t.Errorf("get: %v", err)
 	}
@@ -804,7 +804,7 @@ func TestTxn_Renew(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	val, err = txn.Get(dbroot, []byte("k"))
+	val, err := txn.Get(dbroot, []byte("k"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -1097,8 +1097,6 @@ func BenchmarkTxn_Sub_abort(b *testing.B) {
 		defer b.StopTimer()
 		for i := 0; i < b.N; i++ {
 			txn.Sub(func(txn *Txn) (err error) { return e })
-			if e == nil {
-			}
 		}
 		return nil
 	})

--- a/lmdbscan/scanner_test.go
+++ b/lmdbscan/scanner_test.go
@@ -9,10 +9,6 @@ import (
 	"github.com/PowerDNS/lmdb-go/lmdb"
 )
 
-type errcheck func(err error) (ok bool)
-
-var pIsNil = func(err error) bool { return err == nil }
-
 func TestScanner_err(t *testing.T) {
 	env, err := lmdbtest.NewEnv(nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #25 

This PR resolves all of the issues reported by the `staticcheck` tool in tests. 

I think it's mostly boring, except possibly this removed code in `BenchmarkTxn_Sub_abort()`:

```diff
                for i := 0; i < b.N; i++ {
                        txn.Sub(func(txn *Txn) (err error) { return e })
-                       if e == nil {
-                       }
                }
```

I'm not really sure what the intention is, since `e` never changes. If the idea was to add some actual check, it was never added...