### PR TITLE
Fix: allocate C memory for MDB_val in readonly Txn

### DIFF
--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -113,13 +113,13 @@ func (env *Env) FD() (uintptr, error) {
 	// to avoid constant value overflow errors at compile time.
 	const fdInvalid = ^uintptr(0)
 
-	mf := new(C.mdb_filehandle_t)
-	ret := C.mdb_env_get_fd(env._env, mf)
+	var mf C.mdb_filehandle_t
+	ret := C.mdb_env_get_fd(env._env, &mf)
 	err := operrno("mdb_env_get_fd", ret)
 	if err != nil {
 		return 0, err
 	}
-	fd := uintptr(*mf)
+	fd := uintptr(mf)
 
 	if fd == fdInvalid {
 		return 0, errNotOpen

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -943,6 +943,9 @@ func TestTxn_Reset_readonly_C_free(t *testing.T) {
 
 	// Since this is a readonly transaction, the global Env key/val cannot be
 	// reused and new C memory must be allocated.
+	if txn.key == env.ckey || txn.val == env.cval {
+		t.Error("env.ckey and cval must not be used in a readonly Txn")
+	}
 	if txn.cbuf == nil {
 		t.Error("cbuf expected to not be nil when opening a readonly Txn")
 	}
@@ -951,6 +954,18 @@ func TestTxn_Reset_readonly_C_free(t *testing.T) {
 	txn.Reset()
 	if txn.cbuf == nil {
 		t.Error("cbuf must not be nil after Reset")
+		return
+	}
+
+	// Renew must not free the buffer
+	err = txn.Renew()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if txn.cbuf == nil {
+		t.Error("cbuf must not be nil after Reset")
+		return
 	}
 
 	// Abort must free the buffer

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -964,7 +964,7 @@ func TestTxn_Reset_readonly_C_free(t *testing.T) {
 		return
 	}
 	if txn.cbuf == nil {
-		t.Error("cbuf must not be nil after Reset")
+		t.Error("cbuf must not be nil after Renew")
 		return
 	}
 


### PR DESCRIPTION
Use C.malloc to allocate memory for MDB_val in readonly Txn. 

CGo does not allow using new() for this. This can lead to an "cgo argument has Go pointer to unpinned Go pointer" CGo error.

Fixes #28.

TODO:

- [x] ~~Also fix the FD() usage of new() if needed.~~ Not needed, but changed syntax for clarity.

@fiatjaf: does this fix the error you encountered?
