### PR TITLE
Ignore unknown warning options

### DIFF
--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -127,7 +127,7 @@ details about dealing with such situations.
 package lmdb
 
 /*
-#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -Wno-stringop-overflow -O2 -g
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -Wno-unknown-warning-option -Wno-stringop-overflow -O2 -g
 #cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
 
 #include "lmdb.h"


### PR DESCRIPTION
Add `-Wno-unknown-warning-option` to hide these warnings on macOS:

```
warning: unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'? [-Wunknown-warning-option]
```

Closes #31 
