### PR TITLE
CI: minimum CI Go version 1.22 to fix error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,9 +18,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.19'
-          - '1.20'
-          - '1.21'
+          - '1.22'
+          - '1.23'
           - '1.x'
         
     name: Go ${{ matrix.go }} tests


### PR DESCRIPTION
This failure occurs with older versions.

    Run go install golang.org/x/tools/cmd/goimports@latest
    go: downloading golang.org/x/tools v0.28.0
    go: golang.org/x/tools/cmd/goimports@latest (in golang.org/x/tools@v0.28.0): go.mod:3: invalid go version '1.22.0': must match format 1.23

Dropping older versions from CI is consistent with the Go support policy of only supporting the last two versions, but unfortunate.