### PR TITLE
macOS: fix unknown warning -Wno-stringop-overflow

### DIFF
--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -127,7 +127,7 @@ details about dealing with such situations.
 package lmdb
 
 /*
-#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -Wno-stringop-overflow -O2 -g
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -Wno-stringop-overflow -Wno-unknown-warning-option -O2 -g
 #cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
 
 #include "lmdb.h"


### PR DESCRIPTION
Fix this warning by ignoring unknown warning flags:

    warning: unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'? [-Wunknown-warning-option]

Closes #31 
